### PR TITLE
ver 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 sudo: false
 language: ruby
+
 rvm:
   - 2.3.7
   - 2.4.4
   - 2.5.1
+
+branches:
+  only:
+  - master
+
 before_install: gem install bundler

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ inherit_gem:
   commish: commish-defaults.yml
 ```
 
+### Chef Cookbooks
+
+Add the following to your project's `.rubocop.yml` file:
+
+```yaml
+inherit_from:
+  - 'https://raw.githubusercontent.com/kbeckman/commish/<latest-tag>/commish-defaults.yml'
+```
+
 
 ## References
 

--- a/commish-defaults.yml
+++ b/commish-defaults.yml
@@ -64,6 +64,9 @@ Metrics/BlockLength:
 Metrics/LineLength:
   Max: 120
 
+Naming/VariableNumber:
+  EnforcedStyle: snake_case
+
 Style/AutoResourceCleanup:
   Enabled: true
 

--- a/commish-defaults.yml
+++ b/commish-defaults.yml
@@ -6,6 +6,7 @@ AllCops:
 Layout/AlignHash:
   EnforcedColonStyle: table
   EnforcedHashRocketStyle: table
+  EnforcedLastArgumentHashStyle: ignore_implicit
 
 Layout/BlockAlignment:
   EnforcedStyleAlignWith: start_of_line
@@ -37,17 +38,12 @@ Layout/ClassStructure:
     - protected_methods
     - private_methods
 
-Layout/EmptyLineAfterGuardClause:
-  Enabled: true
-
 Layout/FirstArrayElementLineBreak:
-  Enabled: true
-
-Layout/FirstHashElementLineBreak:
   Enabled: true
 
 Layout/MultilineAssignmentLayout:
   Enabled: true
+  EnforcedStyle: same_line
 
 Lint/InheritException:
   EnforcedStyle: standard_error
@@ -71,6 +67,9 @@ Style/AutoResourceCleanup:
   Enabled: true
 
 Style/CollectionMethods:
+  Enabled: true
+
+Style/EmptyLineAfterGuardClause:
   Enabled: true
 
 Style/ImplicitRuntimeError:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0
 
+* TravisCI update for `master` branch builds only
 * RuboCop change for Layout/EmptyLineAfterGuardClause moving to Sytle/EmptyLineAfterGuardClause
 * Removed Layout/FirstHashElementLineBreak 
 * Derivations from RuboCop defaults:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## 0.3.0
 
-* Derivations from Rubocop defaults:
+* RuboCop change for Layout/EmptyLineAfterGuardClause moving to Sytle/EmptyLineAfterGuardClause
+* Removed Layout/FirstHashElementLineBreak 
+* Derivations from RuboCop defaults:
+  - Layout/AlignHash (last argument style, ignore_implicit)
+  - Layout/MultiLineAssignmentLayout (same_line)
   - Naming/VariableNumber (snake_case)
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `commish` Changelog
 
+## 0.3.0
+
+* Derivations from Rubocop defaults:
+  - Naming/VariableNumber (snake_case)
+
+
 ## 0.2.0
 
 * Switched to `asdf` (from `rvm`) for Ruby version management
@@ -11,6 +17,7 @@
   - Style/ClassStructure
     * adding new items for `association` category
     * minor tweaks for `ExpectedOrder`
+
 
 ## 0.1.1 (07/16/2018)
 

--- a/lib/commish/version.rb
+++ b/lib/commish/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Commish
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
## 0.3.0

* TravisCI update for `master` branch builds only
* RuboCop change for Layout/EmptyLineAfterGuardClause moving to Sytle/EmptyLineAfterGuardClause
* Removed Layout/FirstHashElementLineBreak
* Derivations from RuboCop defaults:
  - Layout/AlignHash (last argument style, ignore_implicit)
  - Layout/MultiLineAssignmentLayout (same_line)
  - Naming/VariableNumber (snake_case)
