### PR TITLE
ver 0.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
-sudo: false
+sudo: required
 language: ruby
 
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3
+  - 2.4
+  - 2.5
 
 branches:
   only:

--- a/commish-defaults.yml
+++ b/commish-defaults.yml
@@ -38,6 +38,9 @@ Layout/ClassStructure:
     - protected_methods
     - private_methods
 
+Layout/EmptyLineAfterGuardClause:
+  Enabled: true
+
 Layout/FirstArrayElementLineBreak:
   Enabled: true
 
@@ -67,9 +70,6 @@ Style/AutoResourceCleanup:
   Enabled: true
 
 Style/CollectionMethods:
-  Enabled: true
-
-Style/EmptyLineAfterGuardClause:
   Enabled: true
 
 Style/ImplicitRuntimeError:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # `commish` Changelog
 
-## 0.3.1
+## 0.3.1 (12/12/2018)
 
 * Renamed `Style/EmptyLineAfterGuardClause` to `Layout/EmptyLineAfterGuardClause` to correspond with the latest RuboCop
   version at the time (`0.61.1`) -- reverts change in `0.3.0`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,25 +1,33 @@
 # `commish` Changelog
 
-## 0.3.0
+## 0.3.1
+
+* Renamed `Style/EmptyLineAfterGuardClause` to `Layout/EmptyLineAfterGuardClause` to correspond with the latest RuboCop
+  version at the time (`0.61.1`) -- reverts change in `0.3.0`
+* Added `sudo: required` for `.travis.yml` (due to a Travis-CI notification indicating forced VM-based builds)
+* Removed Ruby patch number from `.travis.yml` supported versions so the latest is automatically chosen
+
+
+## 0.3.0 (11/01/2018)
 
 * TravisCI update for `master` branch builds only
-* RuboCop change for Layout/EmptyLineAfterGuardClause moving to Sytle/EmptyLineAfterGuardClause
-* Removed Layout/FirstHashElementLineBreak 
+* RuboCop change for `Layout/EmptyLineAfterGuardClause` moving to `Sytle/EmptyLineAfterGuardClause`
+* Removed `Layout/FirstHashElementLineBreak` 
 * Derivations from RuboCop defaults:
-  - Layout/AlignHash (last argument style, ignore_implicit)
-  - Layout/MultiLineAssignmentLayout (same_line)
-  - Naming/VariableNumber (snake_case)
+  - `Layout/AlignHash` (last argument style, ignore_implicit)
+  - `Layout/MultiLineAssignmentLayout` (same_line)
+  - `Naming/VariableNumber` (snake_case)
 
 
-## 0.2.0
+## 0.2.0 (09/24/2018)
 
 * Switched to `asdf` (from `rvm`) for Ruby version management
 * Removed _all_ version constraints for development dependencies
 * Derivations from RuboCop defaults:
-  - AllCops (excluding `db/schema.rb` generated files)
-  - Sytle/RedundantException (disabled)
+  - `AllCops` (excluding `db/schema.rb` generated files)
+  - `Sytle/RedundantException` (disabled)
     * Sometimes it makes sense to: `raise RuntimeError, 'error message'`
-  - Style/ClassStructure
+  - `Style/ClassStructure`
     * adding new items for `association` category
     * minor tweaks for `ExpectedOrder`
 
@@ -38,22 +46,22 @@
 * Initial project release.
 * Rules correspond to cops / settings available in RubCop `0.57`.
 * Derivations from RuboCop defaults:
-  - Layout/AlignHash (table formatted)
-  - Layout/BlockAlignment (start of line)
-  - Layout/ClassStructure (enabled, _assuming some additional tweaks_)
-  - Layout/EmptyLineAfterGuardClause (enabled)
-  - Layout/FirstArrayElementLineBreak (enabled)
-  - Layout/FirstHashElementLineBreak (enabled)
-  - Layout/MultilineAssignmentLayout (enabled)
-  - Lint/InheritException (enforce `StandardError`)
-  - Lint/NumberConversion (enabled)
-  - Metrics/BlockLength (_exclusions_)
-  - Metrics/LineLength (max: 120)
-  - Style/AutoResourceCleanup (enabled)
-  - Style/CollectionMethods (enabled)
-  - Style/ImplicitRuntimeError (enabled)
-  - Style/MethodCalledOnDoEndBlock (enabled)
-  - Style/OptionHash (enabled)
-  - Style/ReturnNil (enabled)
-  - Style/Send (enabled)
-  - Style/StringMethods (enabled)
+  - `Layout/AlignHash` (table formatted)
+  - `Layout/BlockAlignment` (start of line)
+  - `Layout/ClassStructure` (enabled, _assuming some additional tweaks_)
+  - `Layout/EmptyLineAfterGuardClause` (enabled)
+  - `Layout/FirstArrayElementLineBreak` (enabled)
+  - `Layout/FirstHashElementLineBreak` (enabled)
+  - `Layout/MultilineAssignmentLayout` (enabled)
+  - `Lint/InheritException` (enforce `StandardError`)
+  - `Lint/NumberConversion` (enabled)
+  - `Metrics/BlockLength` (_exclusions_)
+  - `Metrics/LineLength` (max: 120)
+  - `Style/AutoResourceCleanup` (enabled)
+  - `Style/CollectionMethods` (enabled)
+  - `Style/ImplicitRuntimeError` (enabled)
+  - `Style/MethodCalledOnDoEndBlock` (enabled)
+  - `Style/OptionHash` (enabled)
+  - `Style/ReturnNil` (enabled)
+  - `Style/Send` (enabled)
+  - `Style/StringMethods` (enabled)

--- a/lib/commish/version.rb
+++ b/lib/commish/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Commish
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
## 0.3.1

* Renamed Style/EmptyLineAfterGuardClause to `Layout/EmptyLineAfterGuardClause` (due to a `rubocop` change)
* Added `sudo: required` for `.travis.yml` (due to a Travis-CI notification indicating forced VM-based builds)
* Removed Ruby patch number from `.travis.yml` supported versions so the latest is automatically chosen
